### PR TITLE
1차

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -18,7 +18,11 @@ import useWedding from './hooks/useWedding'
 const cx = classNames.bind(styles)
 
 function App() {
-  const { wedding } = useWedding()
+  // useWedding으로 API를 호출하고, 데이터를 가져옵니다.
+  // 관심사를 분리함으로서, 컴포넌트의 역할을 명확히 할 수 있습니다.
+  // 컴포넌트는 UI를 담당하고, 훅은 데이터를 가져오는 역할을 합니다.
+  // 데이터 로직은 분리됐기에 테스트하기도 쉽습니다.
+  const { wedding } = useWedding() // !!
 
   if (wedding == null) {
     return null

--- a/src/components/sections/Calendar.tsx
+++ b/src/components/sections/Calendar.tsx
@@ -61,4 +61,8 @@ function Calendar({ date }: { date: string }) {
   )
 }
 
+// memo를 사용하여 props가 변경되지 않으면 리렌더링을 방지합니다.
+// 만약 부모 컴포넌트에서 useState를 사용하여 상태를 변경해도
+// calendar에 넘기는 date 값이 변경되지 않으면 리렌더링되지 않습니다.
+// ImageViewer는 open props값에 따라 리렌더링되므로 memo를 사용하지 않습니다.
 export default memo(Calendar)

--- a/src/components/sections/Heading.tsx
+++ b/src/components/sections/Heading.tsx
@@ -6,6 +6,9 @@ import Section from '@shared/Section'
 
 const cx = classNames.bind(styles)
 
+/**
+ * 리렌더링에 영향을 받지 않는 상수 변수는 컴포넌트 밖에 선언합니다.
+ */
 const days = [
   'Sunday',
   'Monday',

--- a/src/components/sections/ImageGallery.tsx
+++ b/src/components/sections/ImageGallery.tsx
@@ -40,6 +40,11 @@ function ImageGallery({ images }: { images: string[] }) {
                 handleSelectedImage(idx)
               }}
             >
+              {/* 
+              webp를 사용하면 이미지 용량을 줄일 수 있습니다.
+              하지만 IE에서는 webp를 지원하지 않기에 jpg 파일도 함께 제공합니다.
+              
+              */}
               <picture>
                 <source
                   srcSet={generateImageUrl({

--- a/src/components/sections/ImageGallery.tsx
+++ b/src/components/sections/ImageGallery.tsx
@@ -13,6 +13,11 @@ const cx = classNames.bind(styles)
 function ImageGallery({ images }: { images: string[] }) {
   const [selectedIdx, setSelectedIdx] = useState(-1)
 
+  /** 
+   * selectedIdx가 변할 때 해당 컴포넌트는 리렌더링되므로,
+   * open값은 selectedIdx가 변할 때마다 변경됩니다.
+   * 그래서 useState를 사용해 open 변수를 선언치 않아도 됩니다.
+   * */ 
   const open = selectedIdx > -1
 
   const handleSelectedImage = (idx: number) => {

--- a/src/components/sections/Video.tsx
+++ b/src/components/sections/Video.tsx
@@ -5,8 +5,19 @@ import Section from '../shared/Section'
 
 const cx = classNames.bind(styles)
 
+/** 
+ * 비디오에는 webm, mp4 두 가지 형식의 비디오 파일이 있습니다.
+ * webm은 구글에서 만든 비디오 포맷으로, 고화질의 비디오를 높은 압축률로 저장할 수 있습니다.
+ * 단, IE에서는 지원하지 않기에 mp4 파일도 함께 제공합니다.
+ * */ 
 function Video() {
   return (
+
+    /**
+     * - video의 autoplay와 muted
+     * video에 source를 지정하면, autoplay를 해당 자동재생되지 않습니다.
+     * 이 경우 muted 속성을 추가하면 자동재생이 가능합니다.
+     * */ 
     <Section className={cx('container')}>
       <video autoPlay loop muted poster="/assets/poster.jpg">
         <source src="/assets/main.webm" type="video/webm" />

--- a/src/components/shared/ErrorBoundary.tsx
+++ b/src/components/shared/ErrorBoundary.tsx
@@ -9,6 +9,13 @@ interface ErrorBoundaryState {
   hasError: boolean
 }
 
+
+/**
+ * ErrorBoundary?
+ * 에러가 발생했을 때, 에러 메시지를 보여줄 수 있습니다.
+ * 하위 컴포넌트에서 발생하는 JS 관련 에러를 감지하고 fallbackUI를 보여줍니다.
+ * https://ko.legacy.reactjs.org/docs/error-boundaries.html
+ */
 class ErrorBoundary extends React.Component<
   ErrorBoundaryProps,
   ErrorBoundaryState
@@ -22,6 +29,9 @@ class ErrorBoundary extends React.Component<
     return { hasError: true }
   }
 
+  // componentDidCatch?
+  // 하위 컴포넌트에서 발생하는 JS 관련 에러를 감지합니다.
+  // 에러 리포팅 서비스에 에러를 기록할 수도 있습니다.
   componentDidCatch(error: Error, errorInfo: React.ErrorInfo) {
     console.log('error', error)
     console.log('errorInfo', errorInfo)
@@ -29,6 +39,7 @@ class ErrorBoundary extends React.Component<
 
   render() {
     if (this.state.hasError) {
+      // 폴백 UI를 커스텀하여 렌더링할 수 있습니다.
       return this.props.fallbackUI ?? <h1>에러가 발생했습니다.</h1>
     }
 

--- a/src/components/shared/Section.tsx
+++ b/src/components/shared/Section.tsx
@@ -5,6 +5,10 @@ import styles from './Section.module.scss'
 
 const cx = classNames.bind(styles)
 
+/**
+ * Section 컴포넌트는 공통적으로 사용되는 디자인을 별도의 컴포넌트로 뺀 것입니다.
+ * 공통적으로 사용되는 디자인을 별도의 컴포넌트로 뺄 수 있다.
+ */ 
 function Section({
   className,
   children,

--- a/src/contexts/ModalContext.tsx
+++ b/src/contexts/ModalContext.tsx
@@ -36,10 +36,14 @@ export function ModalContext({ children }: { children: React.ReactNode }) {
     setModalState({ ...options, open: true })
   }, [])
 
+  // useCallback은 리렌더링시 함수가 새로 생성되는 것을 방지합니다.
+  // 함수를 캐싱해두고, 의존성이 변경되었을 때만 함수를 재생성합니다.
   const close = useCallback(() => {
     setModalState(defaultValues)
   }, [])
 
+  // useMemo는 리렌더링시 값을 새로 생성하는 것을 방지합니다.
+  // values는 open, close 함수가 변경될 때만 새로 생성됩니다.
   const values = useMemo(
     () => ({
       open,

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -19,6 +19,10 @@ root.render(
     <QueryClientProvider client={queryClient}>
       <ModalContext>
         <ErrorBoundary fallbackUI={<FullScreenMessage type="error" />}>
+        {/* Suspense란
+        Suspense는 리액트에서 비동기 처리를 할 때 사용하는 컴포넌트입니다.
+        로딩 중일 때 보여줄 UI를 설정할 수 있습니다.
+        */}
           <Suspense fallback={<FullScreenMessage type="loading" />}>
             <App />
           </Suspense>

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -18,6 +18,9 @@ root.render(
   <React.StrictMode>
     <QueryClientProvider client={queryClient}>
       <ModalContext>
+        {/* ErrorBoundary
+        에러가 발생했을 때, 에러 메시지를 보여줄 수 있습니다.
+        */}
         <ErrorBoundary fallbackUI={<FullScreenMessage type="error" />}>
         {/* Suspense란
         Suspense는 리액트에서 비동기 처리를 할 때 사용하는 컴포넌트입니다.

--- a/src/scss/font.scss
+++ b/src/scss/font.scss
@@ -4,5 +4,11 @@
         url("../assets/fonts/subset-NanumGeumEunBoHwa.woff2") format("woff2"), 
         url("../assets/fonts/subset-NanumGeumEunBoHwa.woff") format("woff"),
         url("../assets/fonts/subset-NanumGeumEunBoHwa.ttf") format("truetype");
-    font-display: fallback;    
+    font-display: fallback; // !!   
+
+    // - swap(FOUT): 폰트를 다운받기전에는 기본 폰트를 노출하고 다운로드 완료후 폰트를 교체
+    // - block(FOIT): 3초내에 폰트를 다운받지 못하면 기본 폰트를 노출한다.
+    // - fallback(FOIT): 0.1 초 정도 block 이 발생. 3초 이내로 다운받지 못한다면, 다운로드 여부와 상관없이 기본 폰트 노출 (캐시)
+    // - optional(FOIT): fallback 과 비슷하다. 폰트가 다운로드 받는 시간이 너무 오래걸리면 브라우저가 연결을 취소 할 수 있다. (캐시 
+
 }

--- a/src/scss/font.scss
+++ b/src/scss/font.scss
@@ -1,5 +1,8 @@
 @font-face {
     font-family: 'NanumGeumEunBoHwa';
+
+    // font는 woff2 < woff < ttf 순으로 선언하는 것이 좋다.
+    // woff2는 용량이 작지만, 호환성을 위해 woff, ttf도 같이 선언한다.
     src: 
         url("../assets/fonts/subset-NanumGeumEunBoHwa.woff2") format("woff2"), 
         url("../assets/fonts/subset-NanumGeumEunBoHwa.woff") format("woff"),

--- a/src/utils/generateImageUrl.ts
+++ b/src/utils/generateImageUrl.ts
@@ -2,6 +2,8 @@
 // format = jpg | webp
 // option = c_fill, w_400
 
+// 반복적으로 사용되는 로직은 유틸로 분리하는 것이 좋습니다.
+// 계산 함수가 되기 떄문에 테스트 코드 작성하기 쉬워집니다.
 function generateImageUrl({
   filename,
   format,


### PR DESCRIPTION
### 기본
[1. 공통 스타일을 가진 share ui 컴포넌트로 스타일 반복을 줄일 수 있다.](https://github.com/KumJungMin/react-nextjs-part1-wedding/pull/1/commits/4389f9019db94f7a6b87bdb86565fd39eb77969c)
[2. 상수는 컴포넌트 밖에 선언합니다.](https://github.com/KumJungMin/react-nextjs-part1-wedding/pull/1/commits/5fbd6ce7f6c12eaf90a5870f3ddafcf16628ab83)
[3. 비디오 포맷에는 webm, mp4가 있다. 호환성을 위해 2가지 포맷을 제공해야한다.](https://github.com/KumJungMin/react-nextjs-part1-wedding/pull/1/commits/39deddf13df85339416ae5aee496dc07934c0034)
[4. useState 사용에 앞서 주의해야 한다.](https://github.com/KumJungMin/react-nextjs-part1-wedding/pull/1/commits/2d56b23dd60d256aeb205fbebec8bb84f456ea26)
[5. 이미지 용량 감소를 위해 webp 사용을 할수도 있다. 단 호환성을 위해 jpg도 같이 제공해야한다.(picture tag)](https://github.com/KumJungMin/react-nextjs-part1-wedding/pull/1/commits/d007eaa9b308524405fd4d51bcb22d22c9764fcb)

### 요소 최적화
[6. 반복 로직을 계산함수로 분리할 수 있습니다.](https://github.com/KumJungMin/react-nextjs-part1-wedding/pull/1/commits/7355a926d8ef506d323d39f8c0ad92534841bf05)
[7. 폰트를 최적화하는 방법 font-display!](https://github.com/KumJungMin/react-nextjs-part1-wedding/pull/1/commits/6d864fb55a7cc77847a22864e60497a42500d0b4)
[8. 폰트 포맷으로 최적화할 수 있다.](https://github.com/KumJungMin/react-nextjs-part1-wedding/pull/1/commits/652069e12424b2cd6ea4d866c2699c6293f753cd)

### 리액트 최적화
[8. memo를 사용하여 props가 변경되지 않으면 리렌더링을 방지한다.](https://github.com/KumJungMin/react-nextjs-part1-wedding/pull/1/commits/82650813fe28f47554b3f7cd83663d974cb88dad)
[9. useCallback, useMemo로 선언을 캐싱해서 재생성을 막을 수 있다.](https://github.com/KumJungMin/react-nextjs-part1-wedding/pull/1/commits/ea3241838595f38a88b2a28a489267279bf0f9de)
[10. 커스텀 훅으로 비즈니스 로직을 분리하자](https://github.com/KumJungMin/react-nextjs-part1-wedding/pull/1/commits/cce140f88c61a6cb6bc2e754c8c01a6350101f79)
[11. Suspense로 내부 자식 요소가 로딩 중일 때 로딩을 자동처리할 수 있다.](https://github.com/KumJungMin/react-nextjs-part1-wedding/pull/1/commits/d1ab0e6f17cbef0819ebf357c0e5a1fdd8b021e2)
[12. ErrorBoundary로 하위 컴포넌트에서 에러 발생시 대체할 화면을 보여주거나 에러를 기록할 수 있다.](https://github.com/KumJungMin/react-nextjs-part1-wedding/pull/1/commits/fe4def29db033f78e06b96130976ff6ee20b7df9)